### PR TITLE
Improve custom messages and blacklist absolute units

### DIFF
--- a/rules/base.js
+++ b/rules/base.js
@@ -20,7 +20,7 @@ module.exports = {
         'color-named': ['never', {
             'ignoreProperties': ['/^--\\w/'],
             'severity': 'warning',
-            'message': 'Using plain values directly is not allowed, please use a CSS custom property instead.',
+            'message': 'Using named colors is not allowed, please use a CSS custom property instead.',
         }],
         'color-no-invalid-hex': true,
         'comment-empty-line-before': ['always', {
@@ -48,7 +48,7 @@ module.exports = {
         },
         {
             'severity': 'warning',
-            'message': 'Using plain values directly is not allowed, please use a CSS custom property instead.',
+            'message': 'Using color values directly is not allowed, please use a CSS custom property instead.',
         }],
         'function-calc-no-unspaced-operator': true,
         'function-comma-newline-after': 'always-multi-line',
@@ -72,7 +72,7 @@ module.exports = {
         },
         {
             'severity': 'warning',
-            'message': 'Using plain values directly is not allowed, please use a CSS custom property instead.',
+            'message': 'Please use em units inside media queries.',
         }],
         'media-feature-parentheses-space-inside': 'never',
         'media-feature-range-operator-space-after': 'always',

--- a/rules/base.js
+++ b/rules/base.js
@@ -20,7 +20,7 @@ module.exports = {
         'color-named': ['never', {
             'ignoreProperties': ['/^--\\w/'],
             'severity': 'warning',
-            'message': 'Using named colors is not allowed, please use a CSS custom property instead.',
+            'message': 'Using named colors is not recommended, please consider using a CSS custom property instead.',
         }],
         'color-no-invalid-hex': true,
         'comment-empty-line-before': ['always', {
@@ -48,7 +48,7 @@ module.exports = {
         },
         {
             'severity': 'warning',
-            'message': 'Using color values directly is not allowed, please use a CSS custom property instead.',
+            'message': 'Using color values directly is not recommended, please consider using a CSS custom property instead.',
         }],
         'function-calc-no-unspaced-operator': true,
         'function-comma-newline-after': 'always-multi-line',
@@ -72,7 +72,7 @@ module.exports = {
         },
         {
             'severity': 'warning',
-            'message': 'Please use em units inside media queries.',
+            'message': 'Using units other than em is not recommended. You can understand why by reading: https://zellwk.com/blog/media-query-units/',
         }],
         'media-feature-parentheses-space-inside': 'never',
         'media-feature-range-operator-space-after': 'always',
@@ -101,6 +101,7 @@ module.exports = {
         'string-quotes': 'double',
         'unit-blacklist': [['px', 'pt', 'pc', 'in', 'cm', 'mm'], {
             'severity': 'warning',
+            'message': 'Using absolute units is not recommended. Consider using relative units: https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Values_and_units#Relative_length_units',
         }],
         'value-list-comma-newline-after': 'always-multi-line',
         'value-list-comma-space-after': 'always-single-line',

--- a/rules/base.js
+++ b/rules/base.js
@@ -99,6 +99,9 @@ module.exports = {
         'selector-no-vendor-prefix': true,
         'selector-pseudo-element-colon-notation': 'double',
         'string-quotes': 'double',
+        'unit-blacklist': [['px', 'pt', 'pc', 'in', 'cm', 'mm'], {
+            'severity': 'warning',
+        }],
         'value-list-comma-newline-after': 'always-multi-line',
         'value-list-comma-space-after': 'always-single-line',
         'value-list-comma-space-before': 'never',

--- a/rules/declaration-strict-value.js
+++ b/rules/declaration-strict-value.js
@@ -9,7 +9,7 @@ const properties = [
 ];
 
 const options = {
-    'ignoreKeywords': ['currentColor', 'transparent', 'inherit'],
+    'ignoreKeywords': ['inherit', 'initial', 'unset'],
     'disableFix': true,
     'severity': 'warning',
     'message': 'Using plain values directly is not allowed, please use a CSS custom property instead.',

--- a/rules/declaration-strict-value.js
+++ b/rules/declaration-strict-value.js
@@ -9,10 +9,10 @@ const properties = [
 ];
 
 const options = {
-    'ignoreKeywords': ['inherit', 'initial', 'unset'],
+    'ignoreKeywords': ['auto', 'inherit', 'initial', 'unset'],
     'disableFix': true,
     'severity': 'warning',
-    'message': 'Using plain values directly is not allowed, please use a CSS custom property instead.',
+    'message': 'Using plain values directly is not recommended, please consider using a CSS custom property instead.',
 };
 
 module.exports = {

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -39,6 +39,12 @@ Array [
     "severity": "warning",
   },
   Object {
+    "column": 16,
+    "line": 13,
+    "rule": "unit-blacklist",
+    "severity": "warning",
+  },
+  Object {
     "column": 5,
     "line": 14,
     "rule": "scale-unlimited/declaration-strict-value",
@@ -69,9 +75,21 @@ Array [
     "severity": "warning",
   },
   Object {
+    "column": 20,
+    "line": 22,
+    "rule": "unit-blacklist",
+    "severity": "warning",
+  },
+  Object {
     "column": 43,
     "line": 22,
     "rule": "media-feature-name-value-whitelist",
+    "severity": "warning",
+  },
+  Object {
+    "column": 20,
+    "line": 24,
+    "rule": "unit-blacklist",
     "severity": "warning",
   },
   Object {
@@ -87,6 +105,24 @@ Array [
     "severity": "warning",
   },
   Object {
+    "column": 45,
+    "line": 28,
+    "rule": "unit-blacklist",
+    "severity": "warning",
+  },
+  Object {
+    "column": 20,
+    "line": 30,
+    "rule": "unit-blacklist",
+    "severity": "warning",
+  },
+  Object {
+    "column": 18,
+    "line": 34,
+    "rule": "unit-blacklist",
+    "severity": "warning",
+  },
+  Object {
     "column": 5,
     "line": 36,
     "rule": "rule-empty-line-before",
@@ -99,10 +135,28 @@ Array [
     "severity": "warning",
   },
   Object {
+    "column": 20,
+    "line": 38,
+    "rule": "unit-blacklist",
+    "severity": "warning",
+  },
+  Object {
     "column": 1,
     "line": 41,
     "rule": "at-rule-empty-line-before",
     "severity": "error",
+  },
+  Object {
+    "column": 18,
+    "line": 41,
+    "rule": "unit-blacklist",
+    "severity": "warning",
+  },
+  Object {
+    "column": 20,
+    "line": 43,
+    "rule": "unit-blacklist",
+    "severity": "warning",
   },
   Object {
     "column": 15,
@@ -123,10 +177,22 @@ Array [
     "severity": "error",
   },
   Object {
+    "column": 16,
+    "line": 52,
+    "rule": "unit-blacklist",
+    "severity": "warning",
+  },
+  Object {
     "column": 1,
     "line": 54,
     "rule": "comment-empty-line-before",
     "severity": "error",
+  },
+  Object {
+    "column": 16,
+    "line": 57,
+    "rule": "unit-blacklist",
+    "severity": "warning",
   },
   Object {
     "column": 1,
@@ -138,6 +204,24 @@ Array [
     "column": 5,
     "line": 62,
     "rule": "declaration-property-value-blacklist",
+    "severity": "warning",
+  },
+  Object {
+    "column": 17,
+    "line": 63,
+    "rule": "unit-blacklist",
+    "severity": "warning",
+  },
+  Object {
+    "column": 22,
+    "line": 63,
+    "rule": "unit-blacklist",
+    "severity": "warning",
+  },
+  Object {
+    "column": 26,
+    "line": 63,
+    "rule": "unit-blacklist",
     "severity": "warning",
   },
   Object {
@@ -157,6 +241,12 @@ Array [
     "line": 67,
     "rule": "comment-empty-line-before",
     "severity": "error",
+  },
+  Object {
+    "column": 17,
+    "line": 74,
+    "rule": "unit-blacklist",
+    "severity": "warning",
   },
   Object {
     "column": 18,

--- a/test/fixtures/basic.good.css
+++ b/test/fixtures/basic.good.css
@@ -5,7 +5,7 @@
 @mixin bar .foo;
 
 :root {
-    --zero-unit-var: 0px;
+    --zero-unit-var: 0;
     --main-color: red;
     --font-family: "Arial", "Helvetica", sans-serif;
     --font-weight-regular: 400;
@@ -18,7 +18,7 @@
     display: block;
     color: var(--main-color);
     font-family: var(--font-family);
-    font-size: 20px;
+    font-size: 2.5em;
     font-weight: var(--font-weight-regular);
     @mixin bar;
 }
@@ -26,7 +26,7 @@
 @media (width: 60em) {
     .foo {
         border-color: currentColor;
-        font-size: 15px;
+        font-size: 2em;
     }
 }
 
@@ -42,17 +42,17 @@
     }
 }
 
-@media (width <= 600px) {
+@media (width <= 60em) {
     .foo {
         border-color: currentColor;
-        font-size: 15px;
+        font-size: 2em;
     }
 }
 
-@media (width <= 400px) {
+@media (width <= 40em) {
     .foo {
         color: color(var(--main-color) a(0%));
-        font-size: 10px;
+        font-size: 1em;
         fill: transparent;
         stroke: inherit;
     }
@@ -64,14 +64,13 @@
 
 .title {
     font-size: 1em;
-    font-size: 20px;
 }
 
 /* Secondary comment block
    ============================================= */
 
 .description {
-    font-size: 15px;
+    font-size: 1.5em;
 }
 
 /* Tertiary comment block & line/inline comments */
@@ -87,7 +86,7 @@
 
     @nest .foo & {
         background: var(--main-color);
-        box-shadow: 10px 5px 5px var(--color-black);
+        box-shadow: 1em 0.5em 0.5em var(--color-black);
     }
 
     /* Line comment 2 */

--- a/test/fixtures/order.bad.css
+++ b/test/fixtures/order.bad.css
@@ -16,23 +16,23 @@ div {
     bottom: 0;
     left: 0;
 
-    min-width: 1000px;
-    width: 100px;
-    max-width: 50px;
-    min-height: 1000px;
-    height: 100px;
-    max-height: 50px;
+    min-width: 100rem;
+    width: 10rem;
+    max-width: 5rem;
+    min-height: 100rem;
+    height: 10rem;
+    max-height: 5rem;
 
     overflow: hidden;
     z-index: var(--z-index-base);
     overflow-x: auto;
     overflow-y: auto;
 
-    margin-top: 5px;
+    margin-top: 0.5rem;
     margin: 0;
-    margin-left: 5px;
-    margin-right: 5px;
-    padding-top: 5px;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    padding-top: 0.5rem;
     padding: 0;
 
     zoom: 1;
@@ -41,7 +41,7 @@ div {
     /* display */
     display: inline-block;
 
-    flex-basis: 100px;
+    flex-basis: 0.5rem;
     flex: 0 1 auto;
     flex-grow: 1;
     flex-shrink: 1;
@@ -84,9 +84,9 @@ div {
     table-layout: fixed;
 
     /* asthethic */
-    border: 1px solid var(--main-color);
+    border: 0.1rem solid var(--main-color);
     list-style: none;
-    outline: 1px solid var(--main-color);
+    outline: 0.1rem solid var(--main-color);
 
     object-fit: contain;
     opacity: 1;
@@ -94,9 +94,9 @@ div {
     clip-path: none;
     background: inherit;
 
-    box-shadow: 10px 5px 5px var(--main-color);
-    border-radius: 5px;
-    filter: blur(5px);
+    box-shadow: 1rem 0.5rem 0.5rem var(--main-color);
+    border-radius: 0.5rem;
+    filter: blur(0.5rem);
 
     /* text */
     color: var(--main-color);
@@ -104,7 +104,7 @@ div {
     font-family: var(--font-family);
     font: 2em "Open Sans", sans-serif;
     font-variant: small-caps;
-    font-size: 12px;
+    font-size: 1.2em;
     font-size-adjust: 0.5;
     font-kerning: auto;
     font-weight: var(--font-weight-bold);
@@ -116,14 +116,14 @@ div {
     text-underline-position: under;
     text-decoration: unline;
     text-transform: uppercase;
-    text-shadow: 1px 1px 2px var(--main-color);
+    text-shadow: 0.1rem 0.1rem 0.2rem var(--main-color);
     text-overflow: ellipsis;
     text-align: left;
     text-justify: inter-word;
-    text-indent: 40px;
+    text-indent: 4rem;
 
     tab-size: 4;
-    line-height: 10px;
+    line-height: 1rem;
     white-space: nowrap;
     word-spacing: normal;
     word-wrap: break-word;

--- a/test/fixtures/order.good.css
+++ b/test/fixtures/order.good.css
@@ -12,12 +12,12 @@ div {
     bottom: 0;
     left: 0;
 
-    width: 100px;
-    min-width: 1000px;
-    max-width: 50px;
-    height: 100px;
-    min-height: 1000px;
-    max-height: 50px;
+    width: 10rem;
+    min-width: 100rem;
+    max-width: 5rem;
+    height: 10rem;
+    min-height: 100rem;
+    max-height: 5rem;
 
     z-index: var(--z-index-base);
     overflow: hidden;
@@ -25,15 +25,15 @@ div {
     overflow-y: auto;
 
     margin: 0;
-    margin-top: 5px;
-    margin-right: 5px;
-    margin-bottom: 5px;
-    margin-left: 5px;
+    margin-top: 0.5rem;
+    margin-right: 0.5rem;
+    margin-bottom: 0.5rem;
+    margin-left: 0.5rem;
     padding: 0;
-    padding-top: 5px;
-    padding-right: 5px;
-    padding-bottom: 5px;
-    padding-left: 5px;
+    padding-top: 0.5rem;
+    padding-right: 0.5rem;
+    padding-bottom: 0.5rem;
+    padding-left: 0.5rem;
 
     transform: translateX(0);
     transform-box: auto;
@@ -48,7 +48,7 @@ div {
     display: inline-block;
 
     flex: 0 1 auto;
-    flex-basis: 100px;
+    flex-basis: 10rem;
     flex-grow: 1;
     flex-shrink: 1;
     flex-flow: row wrap;
@@ -113,7 +113,7 @@ div {
     list-style-position: auto;
     list-style-type: auto;
 
-    border: 1px solid var(--main-color);
+    border: 0.1rem solid var(--main-color);
     border-width: auto;
     border-style: auto;
     border-color: var(--main-color);
@@ -134,7 +134,7 @@ div {
     border-left-style: auto;
     border-left-color: var(--main-color);
 
-    outline: 1px solid var(--main-color);
+    outline: 0.1rem solid var(--main-color);
     outline-color: var(--main-color);
     outline-width: auto;
     outline-style: auto;
@@ -156,14 +156,14 @@ div {
     background-attachment: auto;
     background-blend-mode: auto;
 
-    border-radius: 5px;
+    border-radius: 0.5rem;
     border-top-left-radius: auto;
     border-top-right-radius: auto;
     border-bottom-right-radius: auto;
     border-bottom-left-radius: auto;
 
-    box-shadow: 10px 5px 5px var(--main-color);
-    filter: blur(5px);
+    box-shadow: 1rem 0.5rem 0.5rem var(--main-color);
+    filter: blur(0.5rem);
 
     /* text */
     color: var(--main-color);
@@ -177,7 +177,7 @@ div {
     font-variant-ligatures: auto;
     font-variant-numeric: auto;
     font-variant-position: auto;
-    font-size: 12px;
+    font-size: 1.2rem;
     font-size-adjust: 0.5;
     font-kerning: auto;
     font-weight: var(--font-weight-bold);
@@ -196,12 +196,12 @@ div {
     text-decoration-color: var(--main-color);
     text-underline-position: under;
     text-transform: uppercase;
-    text-shadow: 1px 1px 2px var(--main-color);
+    text-shadow: 0.1rem 0.1rem 0.2rem var(--main-color);
     text-overflow: ellipsis;
     text-align: left;
     text-align-last: auto;
     text-justify: inter-word;
-    text-indent: 40px;
+    text-indent: 4rem;
     text-emphasis: auto;
     text-emphasis-color: var(--main-color);
     text-emphasis-position: auto;
@@ -210,7 +210,7 @@ div {
     text-rendering: auto;
     text-combine-upright: auto;
 
-    line-height: 10px;
+    line-height: 1rem;
     tab-size: 4;
     white-space: nowrap;
     letter-spacing: normal;


### PR DESCRIPTION
Changes for this PR:

- Blacklist the use of absolute units - `px`, `pt`, `pc`, `in`, `cm`, `mm`
- Improve messages for some rules to be more meaningful

Closes #61 
