### PR TITLE
fix: remove disableFix on declaration strict value

### DIFF
--- a/rules/declaration-strict-value.js
+++ b/rules/declaration-strict-value.js
@@ -10,7 +10,6 @@ const properties = [
 
 const options = {
     'ignoreKeywords': ['auto', 'inherit', 'initial', 'unset'],
-    'disableFix': true,
     'severity': 'warning',
     'message': 'Using plain values directly is not recommended, please consider using a CSS custom property instead.',
 };


### PR DESCRIPTION
This option is breaking the autofix when saving css files.

Since it is an warning it won´t prompt any error as claimed [here](https://github.com/moxystudio/stylelint-config/pull/54).